### PR TITLE
fix: V2 장부 생성 시 카테고리 선택을 optional로 변경

### DIFF
--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
@@ -58,9 +58,12 @@ public class LedgerService {
         // === 권한 ===
         validateStaffUserRole(agencyUser.getAgencyUserRole());
 
-        Category category = categoryRepository.findByAgencyIdAndName(ledger.getAgency().getId(),
-                request.getCategory())
-            .orElseThrow(() -> new NotFoundException(ErrorCode.LEDGER_CATEGORY_NOT_FOUND));
+        Category category = null;
+        if (request.getCategory() != null && !request.getCategory().isEmpty()) {
+            category = categoryRepository.findByAgencyIdAndName(ledger.getAgency().getId(),
+                    request.getCategory())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.LEDGER_CATEGORY_NOT_FOUND));
+        }
 
         // 장부 내역 등록
         LedgerDetail ledgerDetail = ledgerDetailService.createLedgerDetail(


### PR DESCRIPTION
## Summary
- V2 장부 생성 API에서 카테고리를 선택하지 않았을 때 404 에러가 발생하는 문제 수정
- `category`가 null이거나 빈 문자열일 경우 카테고리 조회를 건너뛰고 null로 저장되도록 변경
- 엔티티, 응답 DTO 모두 nullable category를 지원하므로 설계 의도에 부합

## Test plan
- [ ] V2 장부 생성 API에서 category 없이 호출 시 정상 생성 확인
- [ ] V2 장부 생성 API에서 유효한 category 전달 시 기존과 동일하게 동작 확인
- [ ] V2 장부 생성 API에서 존재하지 않는 category 전달 시 404 에러 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)