### PR TITLE
fix: 장부 통합 report의 합계/지분 계산 보정

### DIFF
--- a/src/main/java/com/moneymong/domain/ledger/api/response/report/LedgerReportResponse.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/response/report/LedgerReportResponse.java
@@ -54,7 +54,8 @@ public record LedgerReportResponse(
             String name,
             Integer income,
             Integer expense,
-            Double share
+            Double incomeShare,
+            Double expenseShare
     ) {
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReportReader.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReportReader.java
@@ -50,15 +50,19 @@ public class LedgerReportReader {
         // 해당 agency의 모든 ledger details 조회
         List<LedgerDetail> allDetails = ledgerDetailRepository.findAllByAgencyId(agencyId);
 
+        // 장부 전체 기간 합계 (응답의 totalIncome/totalExpense/totalBalance, 비율 계산 분모)
+        int totalIncome = calculateTotalByFundType(allDetails, FundType.INCOME);
+        int totalExpense = calculateTotalByFundType(allDetails, FundType.EXPENSE);
+        int totalBalance = totalIncome - totalExpense;
+
         // 기간 필터링
         List<LedgerDetail> filteredDetails = filterByPeriod(allDetails, startYear, startMonth, endYear, endMonth);
 
-        // 총 수입/지출 계산
-        int totalIncome = calculateTotalByFundType(filteredDetails, FundType.INCOME);
-        int totalExpense = calculateTotalByFundType(filteredDetails, FundType.EXPENSE);
-        int totalBalance = totalIncome - totalExpense;
+        // 요청 기간 합계 (멤버별 share 계산용 - 기간 내 비율 의미 유지)
+        int periodIncome = calculateTotalByFundType(filteredDetails, FundType.INCOME);
+        int periodExpense = calculateTotalByFundType(filteredDetails, FundType.EXPENSE);
 
-        // 월별 집계
+        // 월별 집계 (share 분모: 장부 전체 기간 합계)
         List<MonthlyReport> monthlyReports = generateMonthlyReports(
                 filteredDetails,
                 startYear, startMonth,
@@ -67,11 +71,11 @@ public class LedgerReportReader {
                 totalExpense
         );
 
-        // 멤버별 집계
-        List<MemberReport> memberReports = generateMemberReports(filteredDetails, totalIncome, totalExpense);
+        // 멤버별 집계 (share 분모: 요청 기간 합계)
+        List<MemberReport> memberReports = generateMemberReports(filteredDetails, periodIncome, periodExpense);
 
-        // 카테고리별 집계
-        List<CategoryReport> categoryReports = generateCategoryReports(filteredDetails);
+        // 카테고리별 집계 (share 분모: 장부 전체 기간 합계)
+        List<CategoryReport> categoryReports = generateCategoryReports(filteredDetails, totalIncome, totalExpense);
 
         return LedgerReportResponse.builder()
                 .agencyId(agencyId)
@@ -219,8 +223,11 @@ public class LedgerReportReader {
                 .collect(Collectors.toList());
     }
 
-    private List<CategoryReport> generateCategoryReports(List<LedgerDetail> details) {
-        // 수입/지출 분리하여 처리
+    private List<CategoryReport> generateCategoryReports(
+            List<LedgerDetail> details,
+            int totalIncome,
+            int totalExpense
+    ) {
         Map<String, Integer> incomeByCategory = new HashMap<>();
         Map<String, Integer> expenseByCategory = new HashMap<>();
 
@@ -236,11 +243,6 @@ public class LedgerReportReader {
             }
         }
 
-        // 총 수입과 지출 계산
-        int totalIncome = incomeByCategory.values().stream().mapToInt(Integer::intValue).sum();
-        int totalExpense = expenseByCategory.values().stream().mapToInt(Integer::intValue).sum();
-
-        // 모든 카테고리 수집
         Set<String> allCategories = new HashSet<>();
         allCategories.addAll(incomeByCategory.keySet());
         allCategories.addAll(expenseByCategory.keySet());
@@ -250,21 +252,15 @@ public class LedgerReportReader {
                     int income = incomeByCategory.getOrDefault(categoryName, 0);
                     int expense = expenseByCategory.getOrDefault(categoryName, 0);
 
-                    // share는 수입이 있으면 전체 수입 대비, 지출이 있으면 전체 지출 대비
-                    double share;
-                    if (income > 0 && totalIncome > 0) {
-                        share = (double) income / totalIncome;
-                    } else if (expense > 0 && totalExpense > 0) {
-                        share = (double) expense / totalExpense;
-                    } else {
-                        share = 0.0;
-                    }
+                    double incomeShare = totalIncome > 0 ? (double) income / totalIncome : 0.0;
+                    double expenseShare = totalExpense > 0 ? (double) expense / totalExpense : 0.0;
 
                     return CategoryReport.builder()
                             .name(categoryName)
                             .income(income)
                             .expense(expense)
-                            .share(share)
+                            .incomeShare(incomeShare)
+                            .expenseShare(expenseShare)
                             .build();
                 })
                 .sorted(Comparator.comparing(CategoryReport::name))


### PR DESCRIPTION
## Summary

장부 통합 report API(`LedgerReportReader`)의 다음 세 가지 동작을 수정합니다.

1. **`totalIncome` / `totalExpense` / `totalBalance`** — 요청 기간이 아닌 **장부 전체 기간** 합계로 응답하도록 수정. 기존엔 요청 기간으로 필터링된 `filteredDetails` 기준으로 합산되어, 단일 월 요청 시 해당 월 합계만 응답됨.
2. **`monthly[].incomeShareOfPeriod` / `expenseShareOfPeriod`** — 분모를 장부 전체 기간 합계로 변경. 기존엔 요청 기간 내부 합계가 분모라서 단일 월 요청 시 항상 1.0이 응답됨.
3. **`categories[]`** — 단일 `share` 필드를 `incomeShare` / `expenseShare`로 분리. 기존엔 income과 expense가 모두 있는 카테고리에서 expense 비율이 누락됨. 두 분모 모두 장부 전체 기간 합계 기준.

`MemberReport`의 `incomeShare/expenseShare`는 기존 의미(요청 기간 내부 비율)를 유지합니다.

## Test plan

- [ ] 단일 월 요청 시 `totalIncome/totalExpense`가 해당 월 합계가 아닌 장부 전체 합계로 응답되는지 확인
- [ ] 단일 월 요청 시 `monthly[0].incomeShareOfPeriod`가 1.0이 아닌 (해당 월 / 장부 전체) 비율인지 확인
- [ ] 동일 카테고리에 income과 expense가 동시에 있을 때 두 비율 모두 응답에 포함되는지 확인
- [ ] 클라이언트에서 응답 스키마(`categories[].share` 제거, `incomeShare/expenseShare` 추가) 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)