### PR TITLE
feat: 장부 통합 report의 members/categories를 월별로 응답한다

### DIFF
--- a/src/main/java/com/moneymong/domain/ledger/api/response/report/LedgerReportResponse.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/response/report/LedgerReportResponse.java
@@ -13,9 +13,7 @@ public record LedgerReportResponse(
         Integer totalIncome,
         Integer totalExpense,
         Integer totalBalance,
-        List<MonthlyReport> monthly,
-        List<MemberReport> members,
-        List<CategoryReport> categories
+        List<MonthlyReport> monthly
 ) {
     @Builder
     public record PeriodInfo(
@@ -34,7 +32,9 @@ public record LedgerReportResponse(
             Integer expense,
             Integer netAmount,
             Double incomeShareOfPeriod,
-            Double expenseShareOfPeriod
+            Double expenseShareOfPeriod,
+            List<MemberReport> members,
+            List<CategoryReport> categories
     ) {
     }
 

--- a/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReportReader.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReportReader.java
@@ -58,11 +58,7 @@ public class LedgerReportReader {
         // 기간 필터링
         List<LedgerDetail> filteredDetails = filterByPeriod(allDetails, startYear, startMonth, endYear, endMonth);
 
-        // 요청 기간 합계 (멤버별 share 계산용 - 기간 내 비율 의미 유지)
-        int periodIncome = calculateTotalByFundType(filteredDetails, FundType.INCOME);
-        int periodExpense = calculateTotalByFundType(filteredDetails, FundType.EXPENSE);
-
-        // 월별 집계 (share 분모: 장부 전체 기간 합계)
+        // 월별 집계 (각 month 안에 members/categories 포함)
         List<MonthlyReport> monthlyReports = generateMonthlyReports(
                 filteredDetails,
                 startYear, startMonth,
@@ -70,12 +66,6 @@ public class LedgerReportReader {
                 totalIncome,
                 totalExpense
         );
-
-        // 멤버별 집계 (share 분모: 요청 기간 합계)
-        List<MemberReport> memberReports = generateMemberReports(filteredDetails, periodIncome, periodExpense);
-
-        // 카테고리별 집계 (share 분모: 장부 전체 기간 합계)
-        List<CategoryReport> categoryReports = generateCategoryReports(filteredDetails, totalIncome, totalExpense);
 
         return LedgerReportResponse.builder()
                 .agencyId(agencyId)
@@ -90,8 +80,6 @@ public class LedgerReportReader {
                 .totalExpense(totalExpense)
                 .totalBalance(totalBalance)
                 .monthly(monthlyReports)
-                .members(memberReports)
-                .categories(categoryReports)
                 .build();
     }
 
@@ -172,6 +160,10 @@ public class LedgerReportReader {
             double incomeShare = totalIncome > 0 ? (double) monthIncome / totalIncome : 0.0;
             double expenseShare = totalExpense > 0 ? (double) monthExpense / totalExpense : 0.0;
 
+            // 월별 멤버/카테고리 집계 (share 분모: 해당 월 합계)
+            List<MemberReport> monthMembers = generateMemberReports(monthDetails, monthIncome, monthExpense);
+            List<CategoryReport> monthCategories = generateCategoryReports(monthDetails, monthIncome, monthExpense);
+
             reports.add(MonthlyReport.builder()
                     .year(year)
                     .month(month)
@@ -180,6 +172,8 @@ public class LedgerReportReader {
                     .netAmount(netAmount)
                     .incomeShareOfPeriod(incomeShare)
                     .expenseShareOfPeriod(expenseShare)
+                    .members(monthMembers)
+                    .categories(monthCategories)
                     .build());
 
             current = current.plusMonths(1);


### PR DESCRIPTION
## Summary

`LedgerReportResponse`의 최상위 `members` / `categories` 필드를 제거하고, `MonthlyReport` 내부로 옮겨 **월별 멤버/카테고리 집계**를 응답하도록 변경합니다.

기존 구조에서는 요청 기간 전체에 대한 합계 1세트만 응답되어, 클라이언트가 월별 breakdown을 받으려면 월 단위로 요청을 끊어야 했습니다. 변경 후엔 임의 기간(예: 1~5월)을 한 번에 요청해도 `monthly` 배열의 각 월 안에서 멤버/카테고리 데이터를 받을 수 있습니다.

## 변경 내역

- `LedgerReportResponse`: 최상위 `members`, `categories` 필드 제거
- `LedgerReportResponse.MonthlyReport`: `members: List<MemberReport>`, `categories: List<CategoryReport>` 필드 추가
- `LedgerReportReader.generateMonthlyReports`: 각 월의 `monthDetails`로 `generateMemberReports`, `generateCategoryReports` 호출
- 월별 멤버/카테고리의 `incomeShare`/`expenseShare` 분모는 **해당 월 합계**(`monthIncome`, `monthExpense`) 기준
- 데이터 없는 달도 `members: []`, `categories: []`로 row 유지

## 응답 예시 (1~5월 요청)

```json
{
  "totalIncome": 0,
  "totalExpense": 0,
  "totalBalance": 0,
  "monthly": [
    {
      "year": 2024, "month": 1,
      "income": 0, "expense": 0, "netAmount": 0,
      "incomeShareOfPeriod": 0, "expenseShareOfPeriod": 0,
      "members": [ { "userId": 0, "nickname": "...", "income": 0, "expense": 0, "incomeShare": 0, "expenseShare": 0 } ],
      "categories": [ { "name": "...", "income": 0, "expense": 0, "incomeShare": 0, "expenseShare": 0 } ]
    },
    ...
  ]
}
```

## Test plan

- [ ] 1~5월 요청 시 `monthly`가 5개 원소를 갖는지 확인
- [ ] 각 월의 `members`/`categories`가 해당 월 데이터만 반영하는지 확인
- [ ] 데이터 없는 월도 `members: []`, `categories: []`로 응답되는지 확인
- [ ] 클라이언트에서 응답 스키마(최상위 `members`/`categories` 제거, `monthly[].members`/`categories` 추가) 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)